### PR TITLE
Lazily determine the API URL and raise error if not set.

### DIFF
--- a/lib/ddr_aux/client.rb
+++ b/lib/ddr_aux/client.rb
@@ -2,9 +2,11 @@ require "ddr_aux/client/version"
 
 module DdrAux
   module Client
+
     autoload :AdminSet,   "ddr_aux/client/admin_set"
     autoload :Api,        "ddr_aux/client/api"
     autoload :Connection, "ddr_aux/client/connection"
+    autoload :Error,      "ddr_aux/client/error"
     autoload :License,    "ddr_aux/client/license"
     autoload :Model,      "ddr_aux/client/model"
     autoload :Request,    "ddr_aux/client/request"
@@ -13,12 +15,18 @@ module DdrAux
     class << self
       attr_accessor :api_url
 
+      def url
+        api_url || ENV["DDR_AUX_API_URL"] || error("DdrAux::Client API URL is not configured.")
+      end
+
       def uri
-        URI(api_url)
+        URI(url)
+      end
+
+      def error(message)
+        raise Error, message
       end
     end
-
-    self.api_url = ENV["DDR_AUX_API_URL"]
 
     extend Api
   end

--- a/lib/ddr_aux/client/error.rb
+++ b/lib/ddr_aux/client/error.rb
@@ -1,0 +1,5 @@
+module DdrAux::Client
+  class Error < ::StandardError
+
+  end
+end

--- a/lib/ddr_aux/client/version.rb
+++ b/lib/ddr_aux/client/version.rb
@@ -1,5 +1,5 @@
 module DdrAux
   module Client
-    VERSION = "1.2.1"
+    VERSION = "1.2.2"
   end
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -4,6 +4,33 @@ require "ddr_aux/client/admin_set"
 module DdrAux
   RSpec.describe Client do
 
+    describe ".uri" do
+      describe "when the API URL is set by environment variable" do
+        before do
+          allow(ENV).to receive(:[]).with("DDR_AUX_API_URL") { "http://example.com/env" }
+        end
+        it "should be a URI" do
+          expect(described_class.uri).to eq(URI("http://example.com/env"))
+        end
+      end
+      describe "when the API URL is set by attribute" do
+        before do
+          allow(described_class).to receive(:api_url) { "http://example.com/attr" }
+        end
+        it "should be a URI" do
+          expect(described_class.uri).to eq(URI("http://example.com/attr"))
+        end
+      end
+      describe "when the API URL is not set" do
+        before do
+          allow(ENV).to receive(:[]).with("DDR_AUX_API_URL") { nil }
+        end
+        it "should raise an exception" do
+          expect { described_class.uri }.to raise_error(described_class::Error)
+        end
+      end
+    end
+
     describe ".get_license" do
       it "calls License.get" do
         expect(Client::License).to receive(:get).with(1) { nil }


### PR DESCRIPTION
Bumps version to 1.2.2.
Closes #8
